### PR TITLE
add cpu cores per socket

### DIFF
--- a/examples/vm/main.tf
+++ b/examples/vm/main.tf
@@ -9,6 +9,7 @@ module "vm" {
   host               = "host1"
   vm_name            = "TEST-VM-1"
   vm_cpu             = 1
+  vm_core            = 1
   vm_ram             = 1024
   vm_guest_id        = ubuntu64Guest
   vm_iso             = "ubuntu-20.04.6-live-server-amd64.iso"

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "vm_cpu" {
   default     = 1
 }
 
+variable "vm_core" {
+  description = "Number of cores per socket"
+  type        = number
+  default     = 1
+}
+
 variable "vm_ram" {
   description = "Amount of RAM for the vSphere virtual machines (example: 2048)"
   type        = number

--- a/vm.tf
+++ b/vm.tf
@@ -4,10 +4,10 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_id     = data.vsphere_datastore.datastore.id
   host_system_id   = data.vsphere_host.host.id
 
-  num_cpus = var.vm_cpu
-  memory   = var.vm_ram
-
-  guest_id = var.vm_guest_id
+  num_cpus             = var.vm_cpu
+  memory               = var.vm_ram
+  num_cores_per_socket = var.vm_core
+  guest_id             = var.vm_guest_id
 
   network_interface {
     network_id     = data.vsphere_network.network.id


### PR DESCRIPTION
Added cpu core per socket which will define how many cores can be divided. If my total cpu is 8 and I have 2 sockets then var.vm_core value can be 4 which will distribute 4 cores each on two sockets. 